### PR TITLE
BugFix: FoundersRewardAddress index round error

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -69,7 +69,7 @@ exports.createGeneration = function(blockHeight, blockReward, feeReward, recipie
     // txs with founders reward
     if (payFoundersReward === true && maxFoundersRewardBlockHeight >= blockHeight) {
         // calculate founders reward address
-        var index = parseInt(Number(blockHeight / foundersRewardAddressChangeInterval).toFixed(0));
+        var index = parseInt(Number(Math.floor(blockHeight / foundersRewardAddressChangeInterval)).toFixed(0));
         var foundersAddrHash = bitcoin.address.fromBase58Check(vFoundersRewardAddress[index]).hash;
         // pool
         tx.addOutput(


### PR DESCRIPTION
When running Z-NOMP on the zcash testnet, submitted blocks were failing due to the incorrect FoundersReward address being selected.
zcashd debug log shows: 
  ProcessNewBlock AccepBlock Failed
  ContextualCheckBlock: founders reward missing

This should resolve the issue mentioned here:
https://github.com/joshuayabut/z-nomp/issues/66